### PR TITLE
Update rocketpyalpha to rocketpy!

### DIFF
--- a/scripts/install_modules.py
+++ b/scripts/install_modules.py
@@ -8,5 +8,5 @@ print("Installing rocketpy and all its required dependencies...")
 # -m is for defining the module name
 subprocess.check_call([sys.executable, "-m", "pip", "install", "netCDF4>=1.4"])
 print("netCDF4 has been installed.")
-subprocess.check_call([sys.executable, "-m", "pip", "install", "rocketpyalpha"])
+subprocess.check_call([sys.executable, "-m", "pip", "install", "rocketpy"])
 print("rocketpy has been installed.")


### PR DESCRIPTION
RocketPy is out of alpha and should now be installed by `pip install rocketpy`. The `rocketpyalpha` packaged will be deprecated and removed from PyPI by the end of 2021.

By the way, your project is awesome!